### PR TITLE
Feat/request property

### DIFF
--- a/.changeset/chatty-pans-feel.md
+++ b/.changeset/chatty-pans-feel.md
@@ -1,0 +1,5 @@
+---
+"@mocky-balboa/client": minor
+---
+
+Added support for reading the request directly on the route via route.request

--- a/examples/next-js-15/playwright-tests/graphql-example.spec.ts
+++ b/examples/next-js-15/playwright-tests/graphql-example.spec.ts
@@ -1,0 +1,63 @@
+import { test, expect } from "@playwright/test";
+import { createClient, Client } from "@mocky-balboa/playwright";
+import { type Profile, type UserSettings } from "@/lib/graphql";
+
+const graphqlEndpoint = "http://localhost:9082/api/graphql";
+
+let client: Client;
+test.beforeEach(async ({ context }) => {
+  client = await createClient(context);
+});
+
+const profile: Profile = {
+  user: {
+    id: "user-id",
+    name: "John Doe",
+    email: "john.doe@example.com",
+  },
+};
+
+const userSettings: UserSettings = {
+  userSettings: {
+    notificationsEnabled: false,
+    newsletterSubscriptionEnabled: true,
+  },
+};
+
+test("when the data loads for both queries successfully", async ({ page }) => {
+  client.route(graphqlEndpoint, async (route) => {
+    const { operationName } = await route.request.json();
+    switch (operationName) {
+      case "getProfile":
+        return route.fulfill({
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            data: {
+              getProfile: profile,
+            },
+            errors: [],
+          }),
+        });
+      case "getUserSettings":
+        return route.fulfill({
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            data: {
+              getUserSettings: userSettings,
+            },
+            errors: [],
+          }),
+        });
+    }
+
+    return route.passthrough();
+  });
+
+  await page.goto("http://localhost:3000/graphql-example");
+  await expect(page.getByText("John Doe")).toBeVisible();
+  await expect(
+    page.getByText("Newsletter Subscription Enabled: Yes"),
+  ).toBeVisible();
+});

--- a/examples/next-js-15/src/app/graphql-example/graphql.ts
+++ b/examples/next-js-15/src/app/graphql-example/graphql.ts
@@ -1,0 +1,33 @@
+export const makeGraphQLRequest = async <TResponse>(
+  query: string,
+  operationName: string,
+  variables: Record<string, unknown> = {},
+): Promise<TResponse | null> => {
+  try {
+    const response = await fetch("http://localhost:9082/api/graphql", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        query,
+        operationName,
+        variables,
+      }),
+    });
+
+    const responseJson = await response.json();
+    if (!response.ok) {
+      throw new Error(`GraphQL request failed with status ${response.status}`);
+    }
+
+    if (!responseJson.data || !responseJson.data[operationName]) {
+      throw new Error(`GraphQL response is missing data`);
+    }
+
+    return responseJson.data[operationName] as TResponse;
+  } catch (error) {
+    console.error(error);
+    return null;
+  }
+};

--- a/examples/next-js-15/src/app/graphql-example/page.tsx
+++ b/examples/next-js-15/src/app/graphql-example/page.tsx
@@ -1,0 +1,73 @@
+import { Box } from "@/components/box/Box";
+import { Card } from "@/components/card/Card";
+import { Container } from "@/components/container/Container";
+import { DataListError } from "@/components/data-list-error/DataListError";
+import { DataList, DataListProps } from "@/components/data-list/DataList";
+import { Text } from "@/components/text/Text";
+import { Title } from "@/components/title/Title";
+import {
+  Fight,
+  FightStatus,
+  getNextFight,
+  getTrainingRegime,
+  TrainingRegime,
+} from "@/lib/data";
+import { makeGraphQLRequest } from "./graphql";
+import {
+  getProfileQuery,
+  getUserSettingsQuery,
+  type Profile,
+  type UserSettings,
+} from "@/lib/graphql";
+
+export const dynamic = "force-dynamic";
+
+export default async function GraphQLExample() {
+  const [profileData, userSettingsData] = await Promise.all([
+    makeGraphQLRequest<Profile>(getProfileQuery, "getProfile"),
+    makeGraphQLRequest<UserSettings>(getUserSettingsQuery, "getUserSettings"),
+  ]);
+
+  return (
+    <Container>
+      <Box>
+        <Title content={[{ text: "GraphQL Example" }]} />
+        <Text>User Profile:</Text>
+        {profileData && (
+          <Card>
+            <Text>ID: {profileData.user.id}</Text>
+            <Text>Email: {profileData.user.email}</Text>
+            <Text>Name: {profileData.user.name}</Text>
+          </Card>
+        )}
+        {!profileData && (
+          <Card>
+            <Text>No profile data available</Text>
+          </Card>
+        )}
+        <Text>User Settings:</Text>
+        {userSettingsData && (
+          <Card>
+            <Text>
+              Notifications Enabled:{" "}
+              {userSettingsData.userSettings.notificationsEnabled
+                ? "Yes"
+                : "No"}
+            </Text>
+            <Text>
+              Newsletter Subscription Enabled:{" "}
+              {userSettingsData.userSettings.newsletterSubscriptionEnabled
+                ? "Yes"
+                : "No"}
+            </Text>
+          </Card>
+        )}
+        {!userSettingsData && (
+          <Card>
+            <Text>No user settings data available</Text>
+          </Card>
+        )}
+      </Box>
+    </Container>
+  );
+}

--- a/examples/next-js-15/src/lib/graphql.ts
+++ b/examples/next-js-15/src/lib/graphql.ts
@@ -1,0 +1,33 @@
+export const getProfileQuery = `
+  query getProfile {
+    user {
+      id
+      email
+      name
+    }
+  }
+`;
+
+export const getUserSettingsQuery = `
+  query getUserSettings {
+    userSettings {
+      notificationsEnabled
+      newsletterSubscriptionEnabled
+    }
+  }
+`;
+
+export interface Profile {
+  user: {
+    id: string;
+    email: string;
+    name: string;
+  };
+}
+
+export interface UserSettings {
+  userSettings: {
+    notificationsEnabled: boolean;
+    newsletterSubscriptionEnabled: boolean;
+  };
+}

--- a/packages/client/src/route.test.ts
+++ b/packages/client/src/route.test.ts
@@ -256,6 +256,16 @@ describe("Route.fetch", () => {
       }),
     );
   });
+
+  test("the request body stream can be read multiple times", async () => {
+    // Call fetch twice to ensure the request body can be read multiple times
+    await route.fetch();
+    await route.fetch();
+
+    // Read the request body from the original request
+    const requestBody = await route.request.text();
+    expect(requestBody).toEqual(JSON.stringify({ hello: "world" }));
+  });
 });
 
 describe("Route.continue", () => {

--- a/sites/docs.mockybalboa.com/docs/client-guide.mdx
+++ b/sites/docs.mockybalboa.com/docs/client-guide.mdx
@@ -426,3 +426,56 @@ Passthrough results in the request being fulfilled on the server over the networ
 </Tabs>
 
 [Route.passthrough API reference](https://api-reference.mockybalboa.com/classes/_mocky-balboa_client.Route#passthrough).
+
+### request (property)
+
+:::info
+
+First introduced in `@mocky-balboa/client@1.1.0`
+
+:::
+
+The request property is the original request object that was passed to the route handler, an instance of the [Request](https://developer.mozilla.org/en-US/docs/Web/API/Request) class. You can use this to differentiate between how you might want to handle different requests on the same route pattern.
+
+<Tabs groupId="javascript-language">
+  <TabItem value="typescript" label="TypeScript" default>
+      ```TypeScript
+      client.route("**/api", (route) => {
+        const requestMethod = route.request.method;
+        if (requestMethod === "GET") {
+          return route.fulfill({
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ hello: "world" }),
+          });
+        }
+
+        return route.fulfill({
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ hello: "again world" }),
+        });
+      });
+      ```
+  </TabItem>
+  <TabItem value="javascript" label="JavaScript">
+      ```JavaScript
+      client.route("**/api", (route) => {
+        const requestMethod = route.request.method;
+        if (requestMethod === "GET") {
+          return route.fulfill({
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ hello: "world" }),
+          });
+        }
+
+        return route.fulfill({
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ hello: "again world" }),
+        });
+      });
+      ```
+  </TabItem>
+</Tabs>

--- a/sites/docs.mockybalboa.com/docs/client/_category_.json
+++ b/sites/docs.mockybalboa.com/docs/client/_category_.json
@@ -1,6 +1,6 @@
 {
   "label": "Client integrations",
-  "position": 4,
+  "position": 10,
   "link": {
     "type": "generated-index"
   }

--- a/sites/docs.mockybalboa.com/docs/common-use-cases.md
+++ b/sites/docs.mockybalboa.com/docs/common-use-cases.md
@@ -209,5 +209,8 @@ client.route("https://myservice.com/graphql", async (route) => {
         }),
       });
   }
+
+  // Define a fallback behaviour for when the operationName is not recognized
+  return route.passthrough();
 });
 ```

--- a/sites/docs.mockybalboa.com/docs/common-use-cases.md
+++ b/sites/docs.mockybalboa.com/docs/common-use-cases.md
@@ -1,0 +1,213 @@
+---
+sidebar_position: 4
+---
+
+# Common use cases
+
+Here's a list of some common use cases and how they can be implemented with Mocky Balboa. The examples provided are all written using [Playwright](playwright.dev/). However the [Mocky Balboa client](/docs/client-guide) is the same regardless of the testing framework you choose.
+
+## Mocking the same API request across multiple tests
+
+Probably the most common use case is mocking the same API request across multiple tests. Because of how Mocky Balboa scopes mocks to the current test, you can run these tests in parallel without any concern of leaking mocks between tests.
+
+```TypeScript
+import { test, expect } from "@playwright/test";
+import { createClient, Client } from "@mocky-balboa/playwright";
+
+let client: Client;
+test.beforeEach(async ({ context }) => {
+  client = await createClient(context);
+});
+
+test("when there's a network error loading the API data", async ({
+  page,
+}) => {
+  client.route("**/api/data", (route) => {
+    // Simulates a network error, causing any call to "fetch(...)" to throw an error
+    return route.error();
+  });
+
+  // Load the page that calls on the API on the server side
+  await page.goto("http://localhost:3000");
+
+  // Perhaps the page shows an error message here that you want to assert on
+  await expect(page.getByText("Expected error")).toBeVisible();
+});
+
+test("when the API data loads with populated data", async ({
+  page,
+}) => {
+  client.route("**/api/data", (route) => {
+    // Respond with non-empty data set
+    return route.fulfill({
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify([{ id: 1, name: "John Doe" }]),
+    });
+  });
+
+  // Load the page that calls on the API on the server side
+  await page.goto("http://localhost:3000");
+  await expect(page.getByText("John Doe")).toBeVisible();
+});
+
+test("when the API data loads with no data", async ({
+  page,
+}) => {
+  client.route("**/api/data", (route) => {
+    // Respond with empty list
+    return route.fulfill({
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify([]),
+    });
+  });
+
+  // Load the page that calls on the API on the server side
+  await page.goto("http://localhost:3000");
+  await expect(page.getByText("No data found")).toBeVisible();
+});
+```
+
+## Mocking a request n times
+
+You might only want to mock a request a certain number of times. For example, you might have an API endpoint called sequentially with different responses each time. One way to achieve this is by using the `times` property on `client.route`.
+
+```TypeScript
+client.route("**/api/data", (route) => {
+  return route.fulfill({ ... });
+// The route handler will only be called once if the route matches
+}, { times: 1 });
+```
+
+## Asserting the request sent the correct body and headers
+
+Another common use case is asserting the request sent by the server contains the correct body and headers. One way to do this is explicitly assert on the request itself.
+
+```TypeScript
+import { test, expect } from "@playwright/test";
+import { createClient, Client } from "@mocky-balboa/playwright";
+
+let client: Client;
+test.beforeEach(async ({ context }) => {
+  client = await createClient(context);
+});
+
+test("the API is called with the correct request body", async ({
+  page,
+}) => {
+  // Note you don't need to setup a route handler for the request
+  const requestPromise = client.waitForRequest("**/api/data");
+  await page.goto("http://localhost:3000");
+
+  // Make sure you defer waiting on the promise until after you've navigated to the page
+  const request = await requestPromise;
+
+  // Assert on the request body
+  const body = await request.json();
+  expect(body).toEqual({
+    id: "request-id",
+  });
+});
+
+test("the API is called with the correct request headers", async ({
+  page,
+}) => {
+  // Note you don't need to setup a route handler for the request
+  const requestPromise = client.waitForRequest("**/api/data", {
+    // Optionally define a timeout for waiting on the request in ms
+    // Defaults to 5000ms
+    timeout: 8000,
+  });
+
+  await page.goto("http://localhost:3000");
+
+  // Make sure you defer waiting on the promise until after you've navigated to the page
+  const request = await requestPromise;
+
+  // Assert on the request headers
+  expect(request.headers.get("x-custom-header")).toEqual("custom-value");
+});
+```
+
+## Respond with a binary response body
+
+Use files to mock binary response data. The mime type of the file is automatically detected and used to set the correct content type header. You can override this by setting the header manually on `route.fulfill`.
+
+```TypeScript
+client.route("**/user/*/profile-image", (route) => {
+  return route.fulfill({
+    // Relative paths are resolved on the server from the current working directory
+    // i.e. process.cwd()
+    path: "/path/to/image.png",
+  });
+});
+```
+
+## Intercept calls to third party APIs
+
+Sometimes we can work with third-party APIs via SDKs that don't allow us to modify the hostname or base URL. This isn't an issue with Mocky Balboa, as it allows you to intercept any request.
+
+```TypeScript
+// Mock a request to a third-party API
+client.route("https://api.example.com/api/user", (route) => {
+  return route.fulfill({
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      id: "user-id",
+      name: "John Doe",
+      email: "john.doe@example.com",
+    }),
+  });
+});
+```
+
+## Differentiate between requests on the same route handler (GraphQL)
+
+:::info
+
+First introduced in `@mocky-balboa/client@1.1.0`
+
+:::
+
+Perhaps you're calling a POST endpoint multiple times in your test with different payloads (for example a GraphQL API). You can use the `request` property of the `route` object to access the request details and differentiate between them.
+
+```TypeScript
+client.route("https://myservice.com/graphql", async (route) => {
+  const { operationName } = await route.request.json();
+  switch (operationName) {
+    case "getUser":
+      return route.fulfill({
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          data: {
+            user: {
+              id: "user-id",
+              name: "John Doe",
+              email: "john.doe@example.com",
+            },
+          },
+          errors: [],
+        }),
+      });
+
+    case "createUser":
+      return route.fulfill({
+        status: 201,
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          data: {
+            createUser: {
+              id: "new-user-id",
+              name: "Jane Doe",
+              email: "jane.doe@example.com",
+            },
+          },
+          errors: [],
+        }),
+      });
+  }
+});
+```

--- a/sites/docs.mockybalboa.com/docs/features.md
+++ b/sites/docs.mockybalboa.com/docs/features.md
@@ -1,0 +1,16 @@
+---
+sidebar_position: 2
+title: Features
+---
+
+# Features
+
+* **Framework Agnostic:** Seamlessly integrates with any Node.js application or browser automation framework.
+* **Isolated Mocks:** Guarantees that mocks aren't leaked between tests, whilst maintaining parallelism for test runs.
+* **Simple Setup:** Get started with no configuration needed, just follow the quickstart guide.
+* **Binary Support:** Mock binary responses using local files.
+* **Runtime Mocks:** Define mocks directly within your test suite as your tests run.
+* **Advanced Request Matching:** Match server-side requests with a powerful API, similar to Playwright's client-side routing.
+* **Flexible Response Control:** Fulfill requests with mocked data or modify real responses as they happen.
+* **No Code Changes:** Wraps your server runtime without altering your production application code.
+* **Request Assertions:** Verify that your application is making the correct requests.

--- a/sites/docs.mockybalboa.com/docs/getting-started.md
+++ b/sites/docs.mockybalboa.com/docs/getting-started.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 2
+sidebar_position: 3
 ---
 
 # Getting started

--- a/sites/docs.mockybalboa.com/docs/intro.md
+++ b/sites/docs.mockybalboa.com/docs/intro.md
@@ -22,3 +22,8 @@ The server integration is responsible for working inside the same process as you
 ### Client
 
 The client integration is responsible for working inside your browser automation framework. It receives requests from the server and allows you to handle them directly within your test suite.
+
+## Similar solutions
+
+- [@playwright/ssr](https://github.com/playwright-community/ssr) no longer active
+- [request-mocking-protocol](https://github.com/vitalets/request-mocking-protocol)

--- a/sites/docs.mockybalboa.com/docs/server/_category_.json
+++ b/sites/docs.mockybalboa.com/docs/server/_category_.json
@@ -1,6 +1,6 @@
 {
   "label": "Server integrations",
-  "position": 3,
+  "position": 7,
   "link": {
     "type": "generated-index"
   }


### PR DESCRIPTION
### Description

- Adds `request` property to `Route` class. `route.request` can be used to distinguish between requests on the same route handler. A good example being able to handle GraphQL request mocking.
- Adds GraphQL mocking example to `next-js-15` example
- Updates documentation for new functionality
- Adds `features` and `common use cases` to documentation
