### PR TITLE
Release bump

### DIFF
--- a/.changeset/sad-radios-repair.md
+++ b/.changeset/sad-radios-repair.md
@@ -1,0 +1,7 @@
+---
+"@mocky-balboa/cli-utils": major
+"@mocky-balboa/react-router": major
+"@mocky-balboa/vite": major
+---
+
+Full v1 release for @mocky-balboa/cli-utils @mocky-balboa/react-router @mocky-balboa/vite

--- a/.changeset/twelve-schools-stare.md
+++ b/.changeset/twelve-schools-stare.md
@@ -1,0 +1,5 @@
+---
+"@mocky-balboa/server": patch
+---
+
+Bumped msw from 2.10.5 to 2.11.1


### PR DESCRIPTION
### Description

- Release for `@mocky-balboa/server` due to [msw bump](https://github.com/mocky-balboa/mocky-balboa/pull/19)
- v1 release for:
   - `@mocky-balboa/cli-utils`
   - `@mocky-balboa/react-router`
   - `@mocky-balboa/vite`


<!--mocky_balboa_pr_release_description_start-->
  ### Canary releases

  ```
  pnpm i @mocky-balboa/astro@0.0.0-canary-20250901233521
pnpm i @mocky-balboa/cli-utils@0.0.0-canary-20250901233521
pnpm i @mocky-balboa/next-js@0.0.0-canary-20250901233521
pnpm i @mocky-balboa/nuxt@0.0.0-canary-20250901233521
pnpm i @mocky-balboa/react-router@0.0.0-canary-20250901233521
pnpm i @mocky-balboa/server@0.0.0-canary-20250901233521
pnpm i @mocky-balboa/vite@0.0.0-canary-20250901233521
  ```
  <!--mocky_balboa_pr_release_description_end-->