### PR TITLE
chore: patch release

### DIFF
--- a/.changeset/hungry-showers-shave.md
+++ b/.changeset/hungry-showers-shave.md
@@ -1,0 +1,11 @@
+---
+"@mocky-balboa/astro": patch
+"@mocky-balboa/next-js": patch
+"@mocky-balboa/react-router": patch
+"@mocky-balboa/sveltekit": patch
+---
+
+Fixed CLI bin missing hashbangs
+
+- Releases [PR #31](https://github.com/mocky-balboa/mocky-balboa/pull/31)
+  - Addresses [issue #30](https://github.com/mocky-balboa/mocky-balboa/issues/30)


### PR DESCRIPTION
### Description

Releases fix in #31 


<!--mocky_balboa_pr_release_description_start-->
  ### Canary releases

  ```
  pnpm i @mocky-balboa/astro@1.1.5-canary.cde1d7b
pnpm i @mocky-balboa/next-js@1.2.5-canary.cde1d7b
pnpm i @mocky-balboa/react-router@1.1.3-canary.cde1d7b
pnpm i @mocky-balboa/sveltekit@1.0.3-canary.cde1d7b
  ```
  <!--mocky_balboa_pr_release_description_end-->