### PR TITLE
Feature: Alternate overlapping handler priority order with client.setHandlerPriority('last-registed-wins')

### DIFF
--- a/packages/client/src/client.test.ts
+++ b/packages/client/src/client.test.ts
@@ -12,7 +12,11 @@ import {
   MessageType,
   parseMessage,
 } from "@mocky-balboa/websocket-messages";
-import { Client, type ExternalRouteHandlerRouteResponse } from "./client.js";
+import {
+  Client,
+  type ExternalRouteHandlerRouteResponse,
+  HandlerPriority,
+} from "./client.js";
 import { type RawData, type WebSocketServer } from "ws";
 import WebSocket from "isomorphic-ws";
 import {
@@ -397,6 +401,59 @@ describe("Client", () => {
           response: undefined,
         },
       });
+    });
+
+    test("with handlerPriority = 'last-registered-wins', the handler registered last is executed first", async () => {
+      client.setHandlerPriority(HandlerPriority.LastRegisteredWins);
+      const spies = [vi.fn(), vi.fn(), vi.fn()] as const;
+
+      const artificialDelay = async () => {
+        await new Promise((resolve) => setTimeout(resolve, 10));
+      };
+
+      client.route("**/endpoint", async (route) => {
+        await artificialDelay();
+        spies[0](Date.now());
+        return route.fulfill({ status: 200 });
+      });
+
+      client.route("**/endpoint", async (route) => {
+        await artificialDelay();
+        spies[1](Date.now());
+        return route.fallback();
+      });
+
+      client.route("**/endpoint", async (route) => {
+        await artificialDelay();
+        spies[2](Date.now());
+        return route.fallback();
+      });
+
+      const requestMessage = new Message(MessageType.REQUEST, {
+        id: "request-id",
+        request: {
+          method: "GET",
+          url: "http://example.com/endpoint",
+          headers: { Accept: "application/json" },
+        },
+      });
+
+      const idlePromise = waitForAckIdle(serverWs);
+      serverWs.send(requestMessage.toString());
+      await idlePromise;
+
+      expect(spies[2]).toHaveBeenCalled();
+      expect(spies[1]).toHaveBeenCalled();
+      expect(spies[0]).toHaveBeenCalled();
+
+      const spiesCallTimes = [
+        spies[0].mock.calls[0]?.[0],
+        spies[1].mock.calls[0]?.[0],
+        spies[2].mock.calls[0]?.[0],
+      ];
+
+      expect(spiesCallTimes[2]).toBeLessThan(spiesCallTimes[1]);
+      expect(spiesCallTimes[1]).toBeLessThan(spiesCallTimes[0]);
     });
 
     test("when a route is registered to only run 1 time it is removed after running once", async () => {

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -59,6 +59,13 @@ type RouteMeta = RouteOptions & {
   calls: number;
 };
 
+/** Handler priority order, in the case of multiple handlers matching the same request */
+export type HandlerPriority = "first-registered-wins" | "last-registered-wins";
+export const HandlerPriority = {
+  FirstRegisteredWins: "first-registered-wins",
+  LastRegisteredWins: "last-registered-wins",
+} as const;
+
 export interface WaitForRequestOptions {
   /**
    * Timeout duration in milliseconds for waiting for a request to be received from the WebSocket server
@@ -136,6 +143,9 @@ export class Client {
   > = new Map();
   /** Tracks whether an external client side route handler is attached */
   private externalClientSideRouteHandlerAttached = false;
+  /** Priority order for multiple matching handlers */
+  private handlerPriority: HandlerPriority =
+    HandlerPriority.FirstRegisteredWins;
   /** Callback handlers for waiting on client-side network requests */
   private clientWaitForRequestHandlers: Set<
     (request: Request) => Promise<void>
@@ -143,6 +153,9 @@ export class Client {
 
   /** Convenient access to route types */
   public readonly RouteType = RouteType;
+
+  /** Convenient access to handler priorities */
+  public readonly HandlerPriority = HandlerPriority;
 
   /** Registered route handlers to handle outgoing network requests on the server */
   private routeHandlers: Map<
@@ -180,6 +193,17 @@ export class Client {
         resolve();
       });
     });
+  }
+
+  /**
+   * Handlers in the order matching {@link handlerPriority}
+   */
+  private get handlersInPriorityOrder() {
+    if (this.handlerPriority === HandlerPriority.FirstRegisteredWins) {
+      return [...this.routeHandlers];
+    } else {
+      return [...this.routeHandlers].reverse();
+    }
   }
 
   /**
@@ -379,9 +403,9 @@ export class Client {
     const route = new Route(requestObject);
 
     // Iterate over all the route handlers sequentially. This ensures the
-    // correct order of execution.
+    // correct order of execution regardless of handler timing.
     for (const [routeHandlerId, [urlMatcher, handler, routeMeta]] of this
-      .routeHandlers) {
+      .handlersInPriorityOrder) {
       // Skip the handler if the URL does not match
       if (!(await this.doesUrlMatch(urlMatcher, url))) continue;
       // Skip the handler if it should not be handled by the server
@@ -541,6 +565,26 @@ export class Client {
   }
 
   /**
+   * Sets the priority between multiple route handlers that match the same request.
+   *
+   * The default is "first-registered-wins" - the first registered handler matching
+   * a request gets the chance to handle it first. The handlers that were registered later
+   * are run only if the first handler calls {@link Route.fallback}.
+   *
+   * By setting this to "last-registered-wins", the priority is reversed. This matches
+   * e.g. Playwright's mock route handling behavior and enables the following common patterns:
+   * - Registering a default handler for a URL pattern early in a test suite and
+   *   then overriding it in specific tests or for more specific URLs.
+   * - Defining a "catch-all" handler, which detects requests that no other handler, even
+   *   one registered later within a specific test, has mocked.
+   *
+   * @param priority - The handler priority to set.
+   */
+  setHandlerPriority(priority: HandlerPriority) {
+    this.handlerPriority = priority;
+  }
+
+  /**
    * Registers a route handler, when the client receives a request message.
    * @param url - the URL pattern to match against the incoming request URL
    * @param handler - the function to handle the request
@@ -618,7 +662,7 @@ export class Client {
       }
 
       for (const [routeHandlerId, [urlMatcher, handler, routeMeta]] of this
-        .routeHandlers) {
+        .handlersInPriorityOrder) {
         // Skip the handler if the URL does not match
         if (!(await this.doesUrlMatch(urlMatcher, url))) continue;
         // Skip the handler if it should not be handled by the client

--- a/sites/docs.mockybalboa.com/docs/client-guide/client.mdx
+++ b/sites/docs.mockybalboa.com/docs/client-guide/client.mdx
@@ -66,6 +66,125 @@ Registering a route handler allows you to intercept requests and modify the resp
   </TabItem>
 </Tabs>
 
+## Configure handler priority
+
+Mocky Balboa defaults to calling route handlers in the order they were registered in.
+
+<Tabs groupId="javascript-language">
+  <TabItem value="typescript" label="TypeScript" default>
+    ```TypeScript
+    // Matches all user requests
+    client.route("**/api/user/*", (route) => {
+        return route.fulfill({
+          status: 404,
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ error: "Not Found" }),
+        });
+    });
+
+    // Matches a specific user
+    client.route("**/api/user/123", (route) => {
+        return route.fulfill({
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ id: 123, name: 'Test User' }),
+        });
+    });
+
+    // GET .../api/user/1 -> 404
+    // GET .../api/user/123 -> ALSO 404
+    ```
+  </TabItem>
+  <TabItem value="javascript" label="JavaScript">
+    ```JavaScript
+    // Matches all user requests
+    client.route("**/api/user/*", (route) => {
+        return route.fulfill({
+          status: 404,
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ error: "Not Found" }),
+        });
+    });
+
+    // Matches a specific user
+    client.route("**/api/user/123", (route) => {
+        return route.fulfill({
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ id: 123, name: 'Test User' }),
+        });
+    });
+
+    // GET .../api/user/1 -> 404
+    // GET .../api/user/123 -> ALSO 404
+    ```
+  </TabItem>
+</Tabs>
+
+When using the default behavior, make sure to define handlers that should take priority first.
+
+You can change the priority using [Client.setHandlerPriority](https://api-reference.mockybalboa.com/classes/_mocky-balboa_client.Client#setHandlerPriority):
+
+<Tabs groupId="javascript-language">
+  <TabItem value="typescript" label="TypeScript" default>
+    ```TypeScript
+    // Reverse handler priority
+    client.setHandlerPriority("last-registered-wins");
+
+    // Matches all user requests
+    client.route("**/api/user/*", (route) => {
+        return route.fulfill({
+          status: 404,
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ error: "Not Found" }),
+        });
+    });
+
+    // Matches a specific user
+    client.route("**/api/user/123", (route) => {
+        return route.fulfill({
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ id: 123, name: "Test User" }),
+        });
+    });
+
+    // GET .../api/user/1 -> still 404
+    // GET .../api/user/123 -> now gets 200
+    ```
+  </TabItem>
+  <TabItem value="javascript" label="JavaScript">
+    ```JavaScript
+    // Reverse handler priority
+    client.setHandlerPriority("last-registered-wins");
+
+    // Matches all user requests
+    client.route("**/api/user/*", (route) => {
+        return route.fulfill({
+          status: 404,
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ error: "Not Found" }),
+        });
+    });
+
+    // Matches a specific user
+    client.route("**/api/user/123", (route) => {
+        return route.fulfill({
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ id: 123, name: "Test User" }),
+        });
+    });
+
+    // GET .../api/user/1 -> still 404
+    // GET .../api/user/123 -> now gets 200
+    ```
+  </TabItem>
+</Tabs>
+
+This can be useful if you want to define situation-specific route handlers in nested test suites
+or specific tests.
+
 ## Mock n times
 
 :::note[API Reference]


### PR DESCRIPTION
### Description

Add method Client#setHandlerPriority for changing execution / priority order of multiple handlers matching the same request, between:

- 'first-registered-wins' : the previous behavior (default)
- 'last-registered-wins' : "reverse order" similar to Playwright or Cypress mock route handling

Closes #84 