### PR TITLE
Fix `Error: WebSocket is not connected`

### DIFF
--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -536,6 +536,7 @@ export class Client {
       throw new Error("Client is not connected");
     }
 
+    this._ws.removeEventListener("message", this.onMessage);
     this._ws.close();
     delete this._ws;
   }

--- a/packages/playwright/src/playwright.ts
+++ b/packages/playwright/src/playwright.ts
@@ -67,9 +67,12 @@ export const createClient = async (
 
   await client.connect(options);
 
-  context.on("close", () => {
+  const cleanup = () => {
+    context.off("close", cleanup); // Remove self
     client.disconnect();
-  });
+  };
+
+  context.on("close", cleanup);
 
   return client;
 };

--- a/packages/playwright/src/test.ts
+++ b/packages/playwright/src/test.ts
@@ -36,7 +36,7 @@ export const extendTest = <TBaseTest extends typeof base>(
     mockyConnectOptions: { ...mockyConnectOptions },
     mocky: async ({ context, mockyConnectOptions }, use) => {
       const mocky = await createClient(context, mockyConnectOptions);
-      use(mocky);
+      await use(mocky);
     },
   }) as unknown as TestType<
     ExtractTestArgs<TBaseTest> & MockyPlaywrightTest,


### PR DESCRIPTION
### Description
- Ensure the `message` event cleanup occurs on disconnect. Fixes https://github.com/mocky-balboa/mocky-balboa/issues/87

- `use` was missing `await`. See the documentation: https://playwright.dev/docs/test-fixtures#overriding-fixtures

- In some setups, there are redundant steps where `context.close` is called. This does not throw an error by Playwright itself in those cases, but it could potentially cause `Client is not connected/Call connect() before accessing webSocket`. Because `client.disconnect` may be called multiple times. To prevent this, I added logic to remove the `cleanup` after it is called once.