### PR TITLE
Clean up installation instructions in vite.mdx

### DIFF
--- a/sites/docs.mockybalboa.com/docs/server/vite.mdx
+++ b/sites/docs.mockybalboa.com/docs/server/vite.mdx
@@ -20,18 +20,18 @@ How to use Mocky Balboa with [Vite](https://vitejs.dev/).
 
 <Tabs groupId="package-manager">
   <TabItem value="pnpm" label="pnpm" default>
-    ```
-    bash pnpm add -D @mocky-balboa/vite
+    ```bash 
+    pnpm add -D @mocky-balboa/vite
     ```
   </TabItem>
   <TabItem value="npm" label="npm">
-    ```
-    bash npm install -D @mocky-balboa/vite
+    ```bash 
+    npm install -D @mocky-balboa/vite
     ```
   </TabItem>
   <TabItem value="yarn" label="yarn">
-    ```
-    bash yarn add -D @mocky-balboa/vite
+    ```bash 
+    yarn add -D @mocky-balboa/vite
     ```
   </TabItem>
 </Tabs>


### PR DESCRIPTION
Removed redundant bash code blocks from installation instructions.
