### PR TITLE
chore: release client minor + server/ws-messages/playwright patches

### DIFF
--- a/.changeset/bump-uuid.md
+++ b/.changeset/bump-uuid.md
@@ -1,0 +1,7 @@
+---
+"@mocky-balboa/client": patch
+"@mocky-balboa/server": patch
+"@mocky-balboa/websocket-messages": patch
+---
+
+Bump runtime dependency `uuid` from 8.3.2 to 14.0.0.

--- a/.changeset/bump-ws.md
+++ b/.changeset/bump-ws.md
@@ -1,0 +1,5 @@
+---
+"@mocky-balboa/server": patch
+---
+
+Bump runtime dependency `ws` from 7.5.10 to 8.20.1.

--- a/.changeset/feature-set-handler-priority.md
+++ b/.changeset/feature-set-handler-priority.md
@@ -1,0 +1,5 @@
+---
+"@mocky-balboa/client": minor
+---
+
+Add `client.setHandlerPriority('last-registered-wins')` to invert the default overlapping handler priority order so the most recently registered handler wins matches against earlier registrations.

--- a/.changeset/fix-websocket-not-connected.md
+++ b/.changeset/fix-websocket-not-connected.md
@@ -1,0 +1,6 @@
+---
+"@mocky-balboa/client": patch
+"@mocky-balboa/playwright": patch
+---
+
+Fix `Error: WebSocket is not connected` raised when the client attempted to send messages before the underlying WebSocket connection had been established.


### PR DESCRIPTION
## Summary
Adds changesets to publish a release covering merges from 2026-05-20 and 2026-05-21.

### Release plan (from `pnpm changeset status`)
- `@mocky-balboa/client` **2.0.1 → 2.1.0** (minor)
  - feat: `client.setHandlerPriority('last-registered-wins')` (#85)
  - fix: `Error: WebSocket is not connected` (#88)
  - deps: bump `uuid` to 14.0.0 (#95)
- `@mocky-balboa/server` **1.0.9 → 1.0.10** (patch)
  - deps: bump `ws` to 8.20.1 (#93), `uuid` to 14.0.0 (#95)
- `@mocky-balboa/websocket-messages` **1.0.8 → 1.0.9** (patch)
  - deps: bump `uuid` to 14.0.0 (#95)
- `@mocky-balboa/playwright` **2.0.1 → 2.0.2** (patch)
  - fix: `Error: WebSocket is not connected` (#88)

### Cascaded internal-dependency patches
`cypress`, `cli-utils`, `vite`, `astro`, `next-js`, `nuxt`, `react-router`, `sveltekit` — bumped automatically via `updateInternalDependencies: patch`.

### Intentionally not released
- Docs-site only: #96, #89, #86
- devDep-only catalog bumps: #74 (koa/@types/koa), #94 (@fastify/express), #70 (koa)
- Playwright bumps that only touched examples / devDeps (peer range unchanged): #72, #68
- nitropack bump in `nuxt` (devDep only; peer range unchanged): #76

## Test plan
- [ ] CI generates canary releases for affected packages
- [ ] Canary versions are written back into this PR description
- [ ] On merge, CI publishes the release to npm and creates the GitHub releases

🤖 Generated with [Claude Code](https://claude.com/claude-code)