### PR TITLE
feat: able to custom `clientIdentity` instead `uuid()`

### DIFF
--- a/packages/client/src/client.test.ts
+++ b/packages/client/src/client.test.ts
@@ -986,4 +986,9 @@ describe("Client", () => {
       });
     });
   });
+
+  test('client can be construct clientIdentifier', () => {
+    const client = new Client({ clientIdentifier: () => "custom-id" });
+    expect(client.clientIdentifier).toBe("custom-id");
+  });
 });

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -101,6 +101,12 @@ export interface ConnectOptions {
    * @default {@link DefaultWebSocketServerTimeout}
    */
   timeout?: number;
+  /**
+   * Custom function to generate the client identifier. By default, a random UUID is generated for each client instance. The client identifier is used by the server to identify messages from different clients and enable parallel mocking.
+   *
+   * @returns A string to be used as the client identifier
+   */
+  clientIdentifier?: (() => string) | undefined;
 }
 
 /**
@@ -167,8 +173,8 @@ export class Client {
     ]
   > = new Map();
 
-  constructor() {
-    this.clientIdentifier = uuid();
+  constructor({ clientIdentifier }: ConnectOptions = {}) {
+    this.clientIdentifier = clientIdentifier ? clientIdentifier() : uuid();
     this.onMessage = this.onMessage.bind(this);
     this.onRequest = this.onRequest.bind(this);
 

--- a/packages/playwright/src/playwright.ts
+++ b/packages/playwright/src/playwright.ts
@@ -41,7 +41,7 @@ export const createClient = async (
   context: BrowserContext,
   options: ConnectOptions = {},
 ): Promise<Client> => {
-  const client = new Client();
+  const client = new Client(options);
   await context.setExtraHTTPHeaders({
     [ClientIdentityStorageHeader]: client.clientIdentifier,
   });

--- a/packages/playwright/src/test.ts
+++ b/packages/playwright/src/test.ts
@@ -1,5 +1,5 @@
 import type { Client, ConnectOptions } from "@mocky-balboa/client";
-import { test as base, type TestType } from "@playwright/test";
+import { test as base, type TestInfo, type TestType } from "@playwright/test";
 import { createClient } from "./playwright.js";
 
 /**
@@ -13,7 +13,15 @@ export interface MockyPlaywrightTest {
   /**
    * Optional connection options for connecting to the Mocky Balboa server
    */
-  mockyConnectOptions: ConnectOptions;
+  mockyConnectOptions: Omit<ConnectOptions, "clientIdentifier"> & {
+    /**
+     * Custom function to generate the client identifier. By default, a random UUID is generated for each client instance. The client identifier is used by the server to identify messages from different clients and enable parallel mocking.
+     *
+     * @returns A string to be used as the client identifier
+     */
+    clientIdentifier?: (testInfo: TestInfo) => string;
+  };
+  
 }
 
 // Type helpers for extracting generics from the TestType
@@ -30,12 +38,18 @@ type ExtractWorkerArgs<Type> =
  */
 export const extendTest = <TBaseTest extends typeof base>(
   baseTest: TBaseTest,
-  mockyConnectOptions?: ConnectOptions,
+  mockyConnectOptions?: MockyPlaywrightTest["mockyConnectOptions"],
 ) =>
   baseTest.extend<MockyPlaywrightTest>({
     mockyConnectOptions: { ...mockyConnectOptions },
-    mocky: async ({ context, mockyConnectOptions }, use) => {
+    mocky: async ({ context, mockyConnectOptions: {clientIdentifier, ..._mockyConnectOptions} }, use, testInfo) => {
+      const mockyConnectOptions: ConnectOptions = typeof clientIdentifier === "function" && clientIdentifier ? {
+        ..._mockyConnectOptions,
+        clientIdentifier: () => clientIdentifier?.(testInfo),
+      } : _mockyConnectOptions;
+
       const mocky = await createClient(context, mockyConnectOptions);
+      
       await use(mocky);
     },
   }) as unknown as TestType<

--- a/sites/docs.mockybalboa.com/docs/client/playwright.mdx
+++ b/sites/docs.mockybalboa.com/docs/client/playwright.mdx
@@ -216,6 +216,8 @@ Extending globally with `extendTest`:
           port: 1234,
           // Custom timeout for waiting on requests from the server
           timeout: 10000,
+          // Custom function to generate the client identifier
+          clientIdentifier: (testInfo) => `${testInfo.titlePath.join("-")}-${testInfo.testId}`,
         });
         ```
   </TabItem>


### PR DESCRIPTION
### Description

`clientIdentity` acts as the per-test identity. A random uuid makes it hard to correlate thrown errors back to the originating test — particularly on the server side, where logs from multiple tests are interleaved.

Additionally, since we also send test traces to OTel/Honeycomb, using a structured format like `${testInfo.titlePath.filter(Boolean).join(" > ")} (${testInfo.testId})` makes it easy to correlate traces with a specific test, as testId is a unique identifier generated by Playwright.